### PR TITLE
Serve React applicant profile view from portal route

### DIFF
--- a/MergeNew/backend/app/crud.py
+++ b/MergeNew/backend/app/crud.py
@@ -26,7 +26,11 @@ def get_candidates(db: Session, skip: int = 0, limit: int = 10):
 
 ##
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(
+    schemes=["bcrypt"],
+    deprecated="auto",
+    bcrypt__truncate_error=False,
+)
 
 def get_password_hash(password: str):
     return pwd_context.hash(password)

--- a/MergeNew/backend/app/routers/portal.py
+++ b/MergeNew/backend/app/routers/portal.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 from typing import Optional
@@ -11,6 +11,9 @@ from .. import models, schemas, crud, database
 router = APIRouter(prefix="/portal", tags=["portal"])
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
+FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 
 UPLOAD_DIR = BASE_DIR / "uploads"
 UPLOAD_DIR.mkdir(exist_ok=True)
@@ -109,6 +112,9 @@ async def upload_file(
 @router.get("/profile/admin/{user_id}", response_class=HTMLResponse)
 def profile_admin(user_id: int, request: Request, db: Session = Depends(database.get_db)):
     # Admin view of a user's profile (no session requirement)
+    if FRONTEND_INDEX_FILE.exists():
+        return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
+
     db_user = db.query(models.User).filter(models.User.id == user_id).first()
     if not db_user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/MergeNew/backend/frontend/src/App.tsx
+++ b/MergeNew/backend/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import IntakeForm from "./components/Can-intake-form";
 import EvaluationForm from "./components/EvaluationForm";
+import ApplicantProfile from "./components/Applicant_profile";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
         <Route path="/" element={<IntakeForm />} />
         <Route path="/candidate-form" element={<IntakeForm />} />
         <Route path="/evaluation" element={<EvaluationForm />} />
+        <Route path="/portal/profile/admin/:id" element={<ApplicantProfile />} />
       </Routes>
     </Router>
   );

--- a/MergeNew/backend/frontend/src/components/Applicant_profile.tsx
+++ b/MergeNew/backend/frontend/src/components/Applicant_profile.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+
+const ApplicantProfile: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const profileLabel = id ? `Profile Details · ID ${id}` : "Profile Details";
+
+  return (
+    <div className="bg-[#f7f8fa] min-h-screen p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 font-bold">
+            P
+          </div>
+          <span className="font-medium text-gray-700">{profileLabel}</span>
+        </div>
+        <button className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-1 rounded hover:bg-gray-200 text-sm">
+          Send Email
+        </button>
+      </div>
+
+      {/* Progress Bar */}
+      <div className="w-full bg-gray-200 h-2 rounded mb-2">
+        <div className="bg-gray-400 h-2 rounded" style={{ width: "60%" }} />
+      </div>
+      <div className="text-xs text-gray-500 mb-2 ml-1">Progress Indicator</div>
+
+      {/* Tabs */}
+      <div className="bg-white rounded-md shadow-sm flex items-center px-2 py-1 mb-4">
+        <button className="px-3 py-1 font-medium border-b-2 border-gray-700 text-gray-900 text-sm">
+          Overview
+        </button>
+        <button className="px-3 py-1 text-gray-500 text-sm">Documents</button>
+        <button className="px-3 py-1 text-gray-500 text-sm">Settings</button>
+        <button className="px-3 py-1 text-gray-500 text-sm">Forms &gt;</button>
+      </div>
+
+      {/* Main Content */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Left Column */}
+        <div className="space-y-4">
+          <div className="bg-white rounded-md p-4 shadow-sm">
+            <div className="w-full h-28 bg-gray-200 rounded mb-3" />
+            <div className="font-medium text-gray-700 mb-1">Quick Snapshot</div>
+            <div className="space-y-2">
+              <div className="h-3 bg-gray-200 rounded w-3/4" />
+              <div className="h-3 bg-gray-200 rounded w-5/6" />
+              <div className="h-3 bg-gray-200 rounded w-2/3" />
+              <div className="h-3 bg-gray-200 rounded w-4/5" />
+              <div className="h-3 bg-gray-200 rounded w-1/2" />
+            </div>
+          </div>
+        </div>
+        {/* Right Column */}
+        <div className="space-y-4">
+          <div className="bg-white rounded-md p-4 shadow-sm">
+            <div className="font-medium text-gray-700 mb-1">
+              Key Strengths, Likes & Areas of Improvement
+            </div>
+            <div className="text-xs text-gray-400 mb-2">
+              Quick glance of Profile&apos;s Skillset
+            </div>
+            <div className="h-6 bg-gray-200 rounded mb-2 w-3/4" />
+            <div className="h-8 bg-gray-200 rounded mb-2 w-full" />
+            <div className="flex items-center justify-between mb-1">
+              <span className="font-medium text-gray-700 text-sm">Work Availability</span>
+              <button className="text-xs text-gray-500 hover:underline">
+                + Add availability
+              </button>
+            </div>
+            <div className="space-y-2 mb-2">
+              <div className="h-3 bg-gray-200 rounded w-2/3" />
+              <div className="h-3 bg-gray-200 rounded w-1/2" />
+              <div className="h-3 bg-gray-200 rounded w-3/4" />
+            </div>
+            <div className="font-medium text-gray-700 text-sm mb-1">Training &amp; Development</div>
+            <div className="h-16 bg-gray-200 rounded w-full" />
+          </div>
+        </div>
+      </div>
+
+      {/* Add Information Section */}
+      <div className="mt-6">
+        <div className="font-medium text-gray-700 mb-2">Add information</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-white rounded-md p-4 shadow-sm">
+            <div className="font-medium text-gray-700 mb-2">Participants</div>
+            <div className="space-y-2">
+              <div className="h-5 bg-gray-200 rounded w-3/4" />
+              <div className="h-5 bg-gray-200 rounded w-2/3" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicantProfile;
+


### PR DESCRIPTION
## Summary
- allow bcrypt to silently truncate long passwords instead of throwing errors for long credentials
- serve the compiled React frontend for /portal/profile/admin/{user_id} when it exists
- register the applicant profile component in the React router so the page loads for that path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77f4f8c84832db9ffb36152cd4fe3